### PR TITLE
add version number to MANIFEST.MF in plugin too

### DIFF
--- a/org.openntf.domino/manibuild.xml
+++ b/org.openntf.domino/manibuild.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="OpenNTF Domino API" basedir=".">
 	<tstamp>
-		<format property="current.time" pattern="yyyyMMddhhmmss" />
+		<format property="current.time" pattern="yyyyMMddHHmmss" />
 	</tstamp>
 	<target name="Manifest">
 		<manifest file="META-INF/MANIFEST.MF" mode="update">
+			<attribute name="Ant-Version" value="${ant.version}" />
+			<attribute name="Created-By" value="JDK ${java.version} (${java.vendor})" />
+			<attribute name='Implementation-Title' value="OpenNTF Domino API" />
+			<attribute name='Implementation-Version' value="1.0.0_${current.time}" />
+			<attribute name='Implementation-Vendor' value="OpenNTF" />
+			<attribute name='Implementation-Vendor-URL' value="http://www.openntf.org" />
+			<attribute name="Built-By" value="${user.name}" />
+			<attribute name='Build-Date' value="${current.time}" />
+		</manifest>
+		<manifest file="../org.openntf.domino.plugin/META-INF/MANIFEST.MF" mode="update">
 			<attribute name="Ant-Version" value="${ant.version}" />
 			<attribute name="Created-By" value="JDK ${java.version} (${java.vendor})" />
 			<attribute name='Implementation-Title' value="OpenNTF Domino API" />


### PR DESCRIPTION
Factory.loadEnvironment() reads META-INF/MANIFEST.MF in plugin project that we were NOT updating during build. So for example Factory.getVersion() was returning null
