### PR TITLE
fixed getParentDocument signature to return org.openntf.domino.Document

### DIFF
--- a/domino/core/src/main/java/org/openntf/domino/ext/Document.java
+++ b/domino/core/src/main/java/org/openntf/domino/ext/Document.java
@@ -118,7 +118,7 @@ public interface Document {
 	 * @return Document that is the parent
 	 * @since org.openntf.domino 2.5.0
 	 */
-	public Document getParentDocument();
+	public org.openntf.domino.Document getParentDocument();
 
 	/**
 	 * Identifies whether any Item on the Document has been updated, used by transactional processing to avoid unnecessary saves.

--- a/domino/xsp/src/main/java/org/openntf/domino/xsp/helpers/OpenntfDominoImplicitObjectFactory.java
+++ b/domino/xsp/src/main/java/org/openntf/domino/xsp/helpers/OpenntfDominoImplicitObjectFactory.java
@@ -47,7 +47,7 @@ public class OpenntfDominoImplicitObjectFactory implements ImplicitObjectFactory
 	 */
 	@Override
 	public void createImplicitObjects(final FacesContextEx ctx) {
-		if (implicitsDone_) {
+		if (!implicitsDone_) {
 			implicitsDone_ = true;
 			if (!ODAPlatform.isAPIEnabled(null))
 				return;


### PR DESCRIPTION
The getParentDocument from org.openntf.domino.ext.Document interface returns the Document interface from the same package. It should instead return org.openntf.domino.Document. The implementation in org.openntf.domino.impl.Document is returning the correct type.