### PR TITLE
changed Base64 Decoder to MimeDecoder

### DIFF
--- a/domino/core/src/main/java/org/openntf/domino/design/impl/AbstractDesignFileResource.java
+++ b/domino/core/src/main/java/org/openntf/domino/design/impl/AbstractDesignFileResource.java
@@ -91,7 +91,7 @@ public abstract class AbstractDesignFileResource extends AbstractDesignBaseNamed
 		switch (getDxlFormat(true)) {
 		case DXL:
 			String rawData = getDxl().selectSingleNode("//filedata").getText(); //$NON-NLS-1$
-			return Base64.getDecoder().decode(rawData);
+			return Base64.getMimeDecoder().decode(rawData);
 		default:
 			return getFileDataRaw(DEFAULT_FILEDATA_FIELD);
 
@@ -111,7 +111,7 @@ public abstract class AbstractDesignFileResource extends AbstractDesignBaseNamed
 					"//item[@name='" + XMLDocument.escapeXPathValue(itemName) + "']/rawitemdata")) { //$NON-NLS-1$ //$NON-NLS-2$
 
 				String rawData = rawitemdata.getText();
-				byte[] thisData = Base64.getDecoder().decode(rawData);
+				byte[] thisData = Base64.getMimeDecoder().decode(rawData);
 				byteStream.write(thisData);
 			}
 

--- a/domino/core/src/main/java/org/openntf/domino/design/impl/ImageResource.java
+++ b/domino/core/src/main/java/org/openntf/domino/design/impl/ImageResource.java
@@ -60,7 +60,7 @@ public final class ImageResource extends AbstractDesignFileResource implements o
 		switch (getDxlFormat(true)) {
 		case DXL:
 			String rawData = getDxl().selectSingleNode("//jpeg|//gif|//png").getText(); //$NON-NLS-1$
-			return Base64.getDecoder().decode(rawData);
+			return Base64.getMimeDecoder().decode(rawData);
 		default:
 			return getFileDataRaw("$ImageData"); //$NON-NLS-1$
 


### PR DESCRIPTION
Fixes #188  .

###Changes proposed in this pull request

`getDxl().selectSingleNode("//filedata").getText()` returns Base64 string in Mime format (max 76 characters, lines separated by \r\n).

This patch changes `Base64.getDecoder()` to `Base64.getMimeDecoder()` to handle this encoding. 

There are couple more calls to `getDecoder` (e.g. in `getFileDataRaw`) that I didn't touch, because I didn't have opportunity to test if returned strings are Mime encoded or not.
